### PR TITLE
Fix for Boards and Text

### DIFF
--- a/cogs/boards.py
+++ b/cogs/boards.py
@@ -265,7 +265,7 @@ class Boards(basecog.Basecog):
             # get position string
             # fmt: off
             if item["user_id"] == member.id:
-                user_position = position
+                author_position = position
                 lines.append(text.fill("boards", "target template",
                     index=f"{position+1:>2}", name=user_name, count=f"{item['count']:>5}"))
             else:
@@ -287,8 +287,12 @@ class Boards(basecog.Basecog):
         ]
         lines = []
         for position in positions:
+            # do not display "YOUR POSITION" if user has no place
+            if author_position < 0:
+                break
+
             # do not display "YOUR POSITION" if user is in "TOP X" and OFFSET is not set
-            if offset == 0 and user_position < config.board_top - config.board_around:
+            if offset == 0 and author_position < config.board_top - config.board_around:
                 break
 
             # do not wrap around (if the 'around' number is too high)

--- a/cogs/boards.py
+++ b/cogs/boards.py
@@ -1,12 +1,11 @@
 import asyncio
-from datetime import datetime
 
 import discord
 from discord import CategoryChannel, VoiceChannel
 from discord.ext import commands
 from discord.abc import PrivateChannel
 
-from core import basecog, check
+from core import basecog
 from core.text import text
 from core.config import config
 from repository import user_channel_repo
@@ -166,7 +165,7 @@ class Boards(basecog.Basecog):
                 continue
 
             # fmt: off
-            if ctx.guild != None and channel.guild.id == ctx.guild.id:
+            if ctx.guild is not None and channel.guild.id == ctx.guild.id:
                 lines.append(text.fill("boards", "channel template",
                     index=f"{position + 1:>2}",
                     count=f"{item['count']:>5}",
@@ -182,7 +181,7 @@ class Boards(basecog.Basecog):
         title = "top number" if offset == 0 else "top offset"
         # fmt: off
         embed.add_field(
-            name=text.fill("boards", title, top=config.board_top, offset=offset+1),
+            name=text.fill("boards", title, top=config.board_top, offset=offset + 1),
             value="\n".join(lines),
             inline=False,
         )
@@ -299,9 +298,9 @@ class Boards(basecog.Basecog):
             # get user object
             item = users[position]
             user = self.bot.get_user(item["user_id"])
-            if user == None:
+            if user is None:
                 user = await self.bot.fetch_user(item["user_id"])
-            if user == None:
+            if user is None:
                 user_name = "_(Unknown user)_"
             else:
                 user_name = discord.utils.escape_mentions(user.display_name)

--- a/core/text.py
+++ b/core/text.py
@@ -73,14 +73,14 @@ class Text:
         if isinstance(channel, discord.TextChannel) or isinstance(channel, discord.VoiceChannel):
             return channel.mention
         if isinstance(channel, int):
-            return f"<#{discord_id}>"
+            return f"<#{channel}>"
         return str(channel)
 
     def _mention_role(self, role):
         if isinstance(role, discord.Role):
             return role.mention
         if isinstance(role, int):
-            return f"<@&{discord_id}>"
+            return f"<@&{role}>"
         return str(role)
 
 


### PR DESCRIPTION
`cogs/boards.py`
- Variable `user_position` was referenced before assignment, updated to initiated `author_position`.

`core/text.py`
- Fill functions for channel and role were using `discord_id` even though their parameters are `channel` and `role`.